### PR TITLE
Removed absurd and useless URL https verification

### DIFF
--- a/CURL/Curl.php
+++ b/CURL/Curl.php
@@ -60,7 +60,7 @@ class Curl extends AbstractCurl
     {
 
         self::$params = $params;
-        
+
         $this->options = array();
 
         if (function_exists('curl_version')) {
@@ -208,9 +208,6 @@ class Curl extends AbstractCurl
         if (ini_get('safe_mode') || ini_get('open_basedir'))
             self::$curlFollowLocation = False;
 
-        if (self::isUrlHttps($this->getURL()))
-            self::$curlSSLVerify = True;
-
         $opts = array(
             CURLOPT_URL => $this->getURL(),
             CURLOPT_HTTPHEADER => self::$params['http_header'],
@@ -249,19 +246,6 @@ class Curl extends AbstractCurl
             );
         }
         return false;
-    }
-
-    /**
-     * Validating/Checking the HTTP or HTTPS from given URL
-     *
-     * @param string $url
-     * @access private
-     * @method isUrlHttps
-     * @return boolean/string
-     */
-    private static function isUrlHttps($url)
-    {
-        return preg_match('/^https:\/\//', $url);
     }
 
     /**

--- a/Tests/Unit/CurlTest.php
+++ b/Tests/Unit/CurlTest.php
@@ -262,18 +262,6 @@ class CurlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Expect:Bar", $content[CURLOPT_HTTPHEADER][0]);
     }
 
-    public function testIsUrlHttps()
-    {
-        $method = new \ReflectionMethod($this->curl, 'isUrlHttps');
-        $method->setAccessible(true);
-
-        $withoutSSL = $method->invokeArgs($this->curl, array('http://foo.net/text.php?id=124'));
-        $withSSL = $method->invokeArgs($this->curl, array('https://boo.com/dummy/123'));
-
-        $this->assertEquals($withoutSSL, 0);
-        $this->assertEquals($withSSL, 1);
-    }
-
     protected function tearDown()
     {
         $this->curl->__destruct();


### PR DESCRIPTION
As I said, this is useless and brings conflicts when people try to connect to a https URL.
The boolean set to true is never used, since the `CURLOPT_SSL_VERIFYPEER` is set up on the configs parameters (If that was its purpose). Which makes sense because you may want to connect to a https URL, but don't want/need CURL to perform a validation on it.
You may want to merge this one, since making the changes straight into your code is not an option for many of us, because we don't deploy the libraries but install them from the live server instead; so.
Hope it helps
